### PR TITLE
Fix #16 where this.timeOutT1 is sometimes null

### DIFF
--- a/lib/nanoTimer.js
+++ b/lib/nanoTimer.js
@@ -372,8 +372,10 @@ NanoTimer.prototype.clearTimeout = function(){
 	if(this.deferredTimeoutRef){
 		clearTimeout(this.deferredTimeoutRef);
 		
-		var difArray = process.hrtime(this.timeOutT1);
-		var difTime = (difArray[0] * 1000000000) + difArray[1];
+    if(this.timeOutT1) {
+      var difArray = process.hrtime(this.timeOutT1);
+      var difTime = (difArray[0] * 1000000000) + difArray[1];
+    }
 		
 		this.deferredTimeout = false;
 	}


### PR DESCRIPTION
process.hrtime(arg) doesn't accept null as an argument. Checking if this.timeOutT1 is non-null before using process.hrtime(this.timeOutT1) to prevent issue #16 