### PR TITLE
Fix package.json to use correct filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanotimer",
-  "main": "./lib/nanoTimer.js",
+  "main": "./lib/nanotimer.js",
   "description": "A much higher accuracy timer object that makes use of the node.js hrtime function call.",
   "version": "0.3.11",
   "authors": [


### PR DESCRIPTION
Looks like you renamed the file [here](https://github.com/Krb686/nanotimer/commit/d875c180bb3551a25480582e14f759e84e2e1135) but forgot to change the package.json