### PR TITLE
fix: add mocha & should as development dependencies & set timeout higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,12 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Krb686/nanotimer.git"
+  },
+  "devDependencies": {
+    "mocha": "^2.3.4",
+    "should": "^7.1.1"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }

--- a/test/test-nanotimer.js
+++ b/test/test-nanotimer.js
@@ -5,6 +5,8 @@ var timerA = new NanoTimer('log');
 
 
 describe('nanoTimer', function(){
+    this.timeout(60 * 1000);
+
     //######## time function #########
     describe('.time', function(){
         


### PR DESCRIPTION
This PR:
* Fixes the dev dependencies
* Adds a `test` script, so one can run `npm test`
* Increases the default test timeout to allow for tests running longer than 2000ms.
* Fixes the travis test (currently a no-op)