### PR TITLE
add config option to change the setImmediate time usage to improve performance

### DIFF
--- a/lib/nanotimer.js
+++ b/lib/nanotimer.js
@@ -43,7 +43,7 @@ function NanoTimer(log = false, config){
 
 	this.timeoutTriggered = false;
 
-	this.timeUntilUseOfSetImmediateInNanoSeconds = config.timeUntilUseOfSetImmediateInNanoSeconds || 25_000_000;
+	this.timeUntilUseOfSetImmediateInNanoSeconds = config?.timeUntilUseOfSetImmediateInNanoSeconds || 25_000_000;
 
 	if(log){
 		this.logging = true;

--- a/lib/nanotimer.js
+++ b/lib/nanotimer.js
@@ -1,4 +1,10 @@
-function NanoTimer(log){
+/**
+ *
+ * @param log {boolean} if logging should be enabled
+ * @param config.timeUntilUseOfSetImmediateInNanoSeconds = 25_000_000
+ * @constructor
+ */
+function NanoTimer(log = false, config){
 
 	var version = process.version;
 	var major = version.split('.')[0];
@@ -36,6 +42,8 @@ function NanoTimer(log){
 	this.intervalType = "";
 
 	this.timeoutTriggered = false;
+
+	this.timeUntilUseOfSetImmediateInNanoSeconds = config.timeUntilUseOfSetImmediateInNanoSeconds || 25_000_000;
 
 	if(log){
 		this.logging = true;
@@ -193,7 +201,7 @@ NanoTimer.prototype.setInterval = function(task, args, interval, callback){
 		if(this.difTime < (this.intervalTime*this.intervalCount)){
 
 			//Can potentially defer to less accurate setTimeout if intervaltime > 25ms
-			if(this.intervalTime > 25000000){
+			if(this.intervalTime > this.timeUntilUseOfSetImmediateInNanoSeconds){
 				if(this.deferredInterval == false){
 					this.deferredInterval = true;
 					var msDelay = (this.intervalTime - 25000000) / 1000000.0;
@@ -317,7 +325,7 @@ NanoTimer.prototype.setTimeout = function(task, args, delay, callback){
 
 	if(difTime < delayTime){
 		//Can potentially defer to less accurate setTimeout if delayTime > 25ms
-		if(delayTime > 25000000){
+		if(delayTime > this.timeUntilUseOfSetImmediateInNanoSeconds){
 			if(this.deferredTimeout == false){
 				this.deferredTimeout = true;
 				var msDelay = (delayTime - 25000000) / 1000000.0;


### PR DESCRIPTION
## Changes

add a new config parameter to the constructor to add a value to change the 25ms value which will be used to decide whether to use setTimeout or setInterval

We had an usecase with an interval of les than 24ms which needed to be accurate and the CPU usage was by 100% because of this - with the value changed to 5ms the performance was better